### PR TITLE
Fix invalid annotation property in ECO:0006154 declaration

### DIFF
--- a/src/ontology/eco-edit.owl
+++ b/src/ontology/eco-edit.owl
@@ -13895,7 +13895,7 @@ SubClassOf(obo:ECO_0006153 obo:ECO_0006151)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ECO:SN"^^xsd:string) obo:IAO_0000115 obo:ECO_0006154 "A type of self-reported individual's statement evidence in which information is provided by a patient in a clinical setting."^^xsd:string)
 AnnotationAssertion(obo:IAO_0000234 obo:ECO_0006154 "Pablo Botas for Foundation 29, Dx29 project"^^xsd:string)
-AnnotationAssertion(oboInOwl:creation_date obo:ECO_0006154 "snadendla"^^xsd:string)
+AnnotationAssertion(oboInOwl:created_by obo:ECO_0006154 "snadendla"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:ECO_0006154 "eco"^^xsd:string)
 AnnotationAssertion(oboInOwl:id obo:ECO_0006154 "ECO:0006154"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:ECO_0006154 "self-reported patient statement evidence"^^xsd:string)


### PR DESCRIPTION
Hi !

Latest version of ECO has an issue in the `ECO:0006154`, where the `obo:creation_date` property was used instead of the `obo:created_by`. This PR fixes that.